### PR TITLE
fix(apps): Força campo networks no modo JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5753,11 +5753,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5770,15 +5772,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5881,7 +5886,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5891,6 +5897,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5903,17 +5910,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5930,6 +5940,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6002,7 +6013,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6012,6 +6024,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6117,6 +6130,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/js/stores/AppVersionsStore.js
+++ b/src/js/stores/AppVersionsStore.js
@@ -75,7 +75,7 @@ var AppVersionsStore = Util.extendObject(EventEmitter.prototype, {
         }
       }
       return memo;
-    }, {});
+    }, {networks: version.networks});
   },
 
   // Diff the new configuration against the current app settings


### PR DESCRIPTION
#### Problema

Ao entrar no modo JSON de uma App, o campo `networks` não estava presente, fazendo com que o backend decida qual valor utilizar. Atualmente, no backend o default é `container/bridge` e caso a App utilize modo `host`, ao atualizar será mudado para `container/bridge`, quebrando a configuração e fazendo a App ter um comportamento diferente do esperado.

#### Solução

Foi adicionado em `AppVersionsStore.getAppConfigVersion( )` o campo `networks` no parser do objeto, forçando a utilizar o valor do formulário no formato JSON. Caso no form não possua nenhum valor setado, usa o default `{ mode: 'host' }`.

#### Outras informações

Ao alterar o comportamento do parser para utilizar todos os valores default, notei que outros campos apareciam no JSON da App e em conversa com o @daltonmatos, decidimos não usa-los para não comprometer o funcionamento do Asgard atualmente.

Os campos que eram omitidos e apareceram são:
```json
{
  "dependencies": [],
  "deployments": [],
  "executor": "",
  "health": [],
  "healthWeight": 0,
  "lastTaskFailure": null,
  "status": null,
  "user": null,
  "tasks": [],
  "tasksRunning": 0,
  "taskStats": {},
  "backoffFactor": 1.15,
  "backoffSeconds": 1,
  "killSelection": "YOUNGEST_FIRST",
  "maxLaunchDelaySeconds": 3600,
  "unreachableStrategy": {
    "unreachableInactiveAfterSeconds": null,
    "unreachableExpungeAfterSeconds": null,
    "inactiveAfterSeconds": 0,
    "expungeAfterSeconds": 0
  },
  "version": "2020-03-25T13:33:40.890Z",
  "versionInfo": {
    "lastScalingAt": "2020-03-25T13:33:40.890000Z",
    "lastConfigChangeAt": "2020-03-25T13:33:40.890000Z"
  }
}
```
